### PR TITLE
Support unsuccessful request responses

### DIFF
--- a/src/protocol/rest-client.ts
+++ b/src/protocol/rest-client.ts
@@ -3,7 +3,8 @@ import { TspClientResponse } from './tsp-client-response';
 
 /**
  * Rest client helper to make request.
- * Errors are thrown when the request response is not 200.
+ * The request response status code indicates if the request is successful.
+ * The json object in the response may be undefined when an error occurs.
  */
 export class RestClient {
     private static async performRequest<T>(verb: string, url: string, body?: any): Promise<TspClientResponse<T>> {
@@ -14,10 +15,9 @@ export class RestClient {
                 'Content-Type': 'application/json'
             },
             method: verb,
-            body: jsonBody
-        });
-        const json = await response.json() as T;
-        return new TspClientResponse(json, response.status, response.statusText);
+            body: jsonBody});
+        const text = await response.text();
+        return new TspClientResponse(text, response.status, response.statusText);
     }
 
     /**

--- a/src/protocol/tsp-client-response.ts
+++ b/src/protocol/tsp-client-response.ts
@@ -1,28 +1,34 @@
 /**
  * Trace Server Protocol response.
- * The response includes the response model from the server, the status code of the HTTP response and the message attached to this response.
+ * The response includes the response model from the server if available,
+ * the status code and message of the HTTP response, and the plain text attached to this response.
  */
 export class TspClientResponse<T> {
-    private readonly responseModel: T;
+    private readonly responseModel: T | undefined;
     private readonly statusCode: number;
     private readonly statusMessage: string;
+    private readonly text: string;
 
     /**
      * Constructor
-     * @param responseModel Model of type T from the server
+     * @param text Plain text of the response from the server
      * @param statusCode Status code from the HTTP response
      * @param statusMessage Status message from the HTTP response
      */
-    constructor(responseModel: T, statusCode: number, statusMessage: string) {
-        this.responseModel = responseModel;
+    constructor(text: string, statusCode: number, statusMessage: string) {
+        this.text = text;
         this.statusCode = statusCode;
         this.statusMessage = statusMessage;
+        try {
+            this.responseModel = JSON.parse(text) as T;
+        } catch (error) {
+        }
     }
 
     /**
-     * Get the model from the server
+     * Get the model from the server, or undefined
      */
-    public getModel(): T {
+    public getModel(): T | undefined {
         return this.responseModel;
     }
 
@@ -34,10 +40,17 @@ export class TspClientResponse<T> {
     }
 
     /**
-     * Get the HTTP status code
+     * Get the HTTP status message
      */
     public getStatusMessage(): string {
         return this.statusMessage;
+    }
+
+    /**
+     * Get the plain text of the response from the server
+     */
+    public getText(): string {
+        return this.text;
     }
 
     /**


### PR DESCRIPTION
When a TSP request response is received with an unsuccessful status code
and without a json object model, the parsing of the body as json was
throwing an error and the status code was unavailable to the caller.

Create the TspClientResponse with the plain text of the response, and
make the model optional. Make the plain text available to the caller. Do
not throw an error when the json object is absent.

Signed-off-by: Patrick Tasse <patrick.tasse@gmail.com>