### PR TITLE
Add prepare script for installing directly from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "node-fetch": "^2.5.0"
   },
   "scripts": {
+    "prepare": "yarn build",
     "build": "tsc",
     "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next --no-git-tag-version --no-commit-hooks"
   }


### PR DESCRIPTION
`yarn` or `npm` run `prepare` script when installing directly from github.

Signed-off-by: Quoc-Hao Tran <quoc-hao.tran@polymtl.ca>