### PR TITLE
Change entry parentId to require

### DIFF
--- a/src/models/entry.ts
+++ b/src/models/entry.ts
@@ -15,9 +15,9 @@ export interface Entry {
     labels: string[];
 
     /**
-     * Parent entry Id. if unset, the entry does not have a parent
+     * Parent entry Id. if -1, the entry does not have a parent
      */
-    parentId?: number;
+    parentId: number;
 
     /**
      * Indicate if the entry will have row data


### PR DESCRIPTION
It seems to me that the `parentId` is always set to -1 if no parent, unless there's a case where it's actually `undefined` that I'm not aware of.

Signed-off-by: Quoc-Hao Tran <quoc-hao.tran@polymtl.ca>