### PR TITLE
Serialize and deserialize timestamps as strings

### DIFF
--- a/src/models/annotation.ts
+++ b/src/models/annotation.ts
@@ -26,12 +26,12 @@ export interface Annotation {
     /**
      * Time of the annotation
      */
-    time: number;
+    time: bigint;
 
     /**
      * Duration of the annotation
      */
-    duration: number;
+    duration: bigint;
 
     /**
      * Entry Id of the annotation

--- a/src/models/bookmark.ts
+++ b/src/models/bookmark.ts
@@ -15,12 +15,12 @@ export interface Bookmark {
     /**
      * Start time for the bookmark
      */
-    startTime: number;
+    startTime: bigint;
 
     /**
      * End time for the bookmark
      */
-    endTime: number;
+    endTime: bigint;
 
     /**
      * Type of the bookmark

--- a/src/models/experiment.ts
+++ b/src/models/experiment.ts
@@ -17,12 +17,12 @@ export interface Experiment {
     /**
      * Experiment's start time
      */
-    start: number;
+    start: bigint;
 
     /**
      * Experiment's end time
      */
-    end: number;
+    end: bigint;
 
     /**
      * Current number of events

--- a/src/models/filter.ts
+++ b/src/models/filter.ts
@@ -15,12 +15,12 @@ export interface Filter {
     /**
      * Start time of the filter
      */
-    startTime: number;
+    startTime: bigint;
 
     /**
      * End time of the filter
      */
-    endTime: number;
+    endTime: bigint;
 
     /**
      * Expression from the filtering language

--- a/src/models/output-descriptor.ts
+++ b/src/models/output-descriptor.ts
@@ -31,12 +31,12 @@ export interface OutputDescriptor {
     /**
      * Start time
      */
-    start: number;
+    start: bigint;
 
     /**
      * End time
      */
-    end: number;
+    end: bigint;
 
     /**
      * Indicate if the start, end times and current model are final,

--- a/src/models/query/query-helper.test.ts
+++ b/src/models/query/query-helper.test.ts
@@ -13,7 +13,7 @@ describe('Query helper tests', () => {
   });
 
   it('Should build a simple time query', () => {
-    const array = [1, 2, 3];
+    const array = [BigInt(1), BigInt(2), BigInt(3)];
     const query = new Query({ [QueryHelper.REQUESTED_TIMES_KEY]: array });
     const test = QueryHelper.timeQuery(array);
 
@@ -21,7 +21,7 @@ describe('Query helper tests', () => {
   });
 
   it('Should build a simple time query with selected items', () => {
-    const times = [1, 2, 3];
+    const times = [BigInt(1), BigInt(2), BigInt(3)];
     const items = [4, 5, 6];
     const query = new Query({
       [QueryHelper.REQUESTED_TIMES_KEY]: times,
@@ -47,10 +47,10 @@ describe('Query helper tests', () => {
   });
 
   it('Should split the range into equal parts', () => {
-    const start = 10;
-    const end = 20;
+    const start = BigInt(10);
+    const end = BigInt(20);
     const parts = 3;
-    const array = [10, 15, 20];
+    const array = [BigInt(10), BigInt(15), BigInt(20)];
     const test = QueryHelper.splitRangeIntoEqualParts(start, end, parts);
 
     expect(test).toEqual(array);

--- a/src/models/query/query-helper.ts
+++ b/src/models/query/query-helper.ts
@@ -44,25 +44,25 @@ export class QueryHelper {
 
     /**
      * Build a simple time query
-     * @param timeRequested Array of requested times
+     * @param requestedTimes Array of requested times
      * @param additionalProperties Use this optional parameter to add custom properties to your query
      */
-    public static timeQuery(timeRequested: number[], additionalProperties?: { [key: string]: any }): Query {
+    public static timeQuery(requestedTimes: bigint[], additionalProperties?: { [key: string]: any }): Query {
         const timeObj = {
-            [this.REQUESTED_TIMES_KEY]: timeRequested
+            [this.REQUESTED_TIMES_KEY]: requestedTimes
         };
         return new Query({ ...timeObj, ...additionalProperties });
     }
 
     /**
      * Build a simple time query with selected items
-     * @param timeRequested Array of requested times
+     * @param requestedTimes Array of requested times
      * @param items Array of item IDs
      * @param additionalProperties Use this optional parameter to add custom properties to your query
      */
-    public static selectionTimeQuery(timeRequested: number[], items: number[], additionalProperties?: { [key: string]: any }): Query {
+    public static selectionTimeQuery(requestedTimes: bigint[], items: number[], additionalProperties?: { [key: string]: any }): Query {
         const selectionTimeObj = {
-            [this.REQUESTED_TIMES_KEY]: timeRequested,
+            [this.REQUESTED_TIMES_KEY]: requestedTimes,
             [this.REQUESTED_ITEMS_KEY]: items
         };
 
@@ -90,22 +90,27 @@ export class QueryHelper {
      * Split the range into equal parts
      * @param start Start time
      * @param end End time
-     * @param nb Number of element or resolution
+     * @param nb Number of elements
      */
-    public static splitRangeIntoEqualParts(start: number, end: number, nb: number): number[] {
-        const result: number[] = new Array(nb);
+    public static splitRangeIntoEqualParts(start: bigint, end: bigint, nb: number): bigint[] {
+        if (nb <= 0) {
+            return [];
+        }
         if (nb === 1) {
-            if (start === end) {
-                result[0] = start;
-                return result;
-            }
+            return [start];
         }
-
-        const stepSize: number = Math.abs(end - start) / (nb - 1);
+        if (start > end) {
+            const tmp = end;
+            end = start;
+            start = tmp;
+        }
+        
+        const result: bigint[] = new Array(nb);
+        const stepSize: number = Number(end - start) / (nb - 1);
         for (let i = 0; i < nb; i++) {
-            result[i] = Math.min(start, end) + Math.round(i * stepSize);
+            result[i] = start + BigInt(Math.floor(i * stepSize));
         }
-        result[result.length - 1] = Math.max(start, end);
+        result[result.length - 1] = end;
         return result;
     }
 }

--- a/src/models/timegraph.ts
+++ b/src/models/timegraph.ts
@@ -8,12 +8,12 @@ export interface TimeGraphEntry extends Entry {
     /**
      * Start time of the entry
      */
-    start: number;
+    start: bigint;
 
     /**
      * End time of the entry
      */
-    end: number;
+    end: bigint;
 }
 
 /**
@@ -45,12 +45,12 @@ export interface TimeGraphState {
     /**
      * Start time of the state
      */
-    start: number;
+    start: bigint;
 
     /**
      * End time of the state
      */
-    end: number;
+    end: bigint;
 
     /**
      * Label to apply to the state
@@ -85,12 +85,12 @@ export interface TimeGraphArrow {
     /**
      * Start time of the arrow
      */
-    start: number;
+    start: bigint;
 
     /**
      * Duration of the arrow
      */
-    end: number;
+    end: bigint;
 
     /**
      * Optional information on the style to format this arrow

--- a/src/models/trace.ts
+++ b/src/models/trace.ts
@@ -15,12 +15,12 @@ export interface Trace {
     /**
      * Trace's start time
      */
-    start: number;
+    start: bigint;
 
     /**
      * Trace's end time
      */
-    end: number;
+    end: bigint;
 
     /**
      * URI of the trace

--- a/src/protocol/__mocks__/rest-client.ts
+++ b/src/protocol/__mocks__/rest-client.ts
@@ -17,8 +17,8 @@ const output: OutputDescriptor = {
     ['key1', 'value1'],
     ['key2', 'value2']
   ]),
-  start: 1,
-  end: 10,
+  start: BigInt(1),
+  end: BigInt(10),
   final: false,
   compatibleProviders: ['One', 'Two']
 };
@@ -44,7 +44,9 @@ export class RestClient {
             params = params.slice(0, params.indexOf('/'));
             let ar = [output];
             ar[0].id = params;
-            client = new TspClientResponse(JSON.stringify(ar), response.status, response.statusText);
+            const replacer = (_key, value) => (typeof value === 'bigint') ? value.toString() + 'n' : value;
+            const reviver = (_key, value) => (typeof value === 'string' && value.match(/(-?\d+)n/)) ? BigInt(value.slice(0, -1)) : value;
+            client = new TspClientResponse(JSON.stringify(ar, replacer), response.status, response.statusText, reviver);
           } else {
             client = new TspClientResponse(params, response.status, response.statusText);
           }

--- a/src/protocol/tsp-client-response.ts
+++ b/src/protocol/tsp-client-response.ts
@@ -14,13 +14,14 @@ export class TspClientResponse<T> {
      * @param text Plain text of the response from the server
      * @param statusCode Status code from the HTTP response
      * @param statusMessage Status message from the HTTP response
+     * @param reviver Optional JSON parse reviver
      */
-    constructor(text: string, statusCode: number, statusMessage: string) {
+    constructor(text: string, statusCode: number, statusMessage: string, reviver?: ((this: any, key: string, value: any) => any)) {
         this.text = text;
         this.statusCode = statusCode;
         this.statusMessage = statusMessage;
         try {
-            this.responseModel = JSON.parse(text) as T;
+            this.responseModel = JSON.parse(text, reviver) as T;
         } catch (error) {
         }
     }

--- a/src/protocol/tsp-client.test.ts
+++ b/src/protocol/tsp-client.test.ts
@@ -92,12 +92,14 @@ describe('Tsp client tests', () => {
         ['key1', 'value1'],
         ['key2', 'value2']
       ]),
-      start: 1,
-      end: 10,
+      start: BigInt(1),
+      end: BigInt(10),
       final: false,
       compatibleProviders: ['One', 'Two']
     };
-    const input = new TspClientResponse(JSON.stringify([output]), 200, 'Success');
+    const replacer = (_key, value) => (typeof value === 'bigint') ? value.toString() + 'n' : value;
+    const reviver = (_key, value) => (typeof value === 'string' && value.match(/(-?\d+)n/)) ? BigInt(value.slice(0, -1)) : value;
+    const input = new TspClientResponse(JSON.stringify([output], replacer), 200, 'Success', reviver);
     const response = await client.experimentOutputs(expUUID);
 
     expect(response).toEqual(input);


### PR DESCRIPTION
Fields that are known to be timestamps or durations are serialized and
deserialized as strings.

This is done to avoid loss of precision in JavaScript 'number' type for
values above Number.MAX_SAFE_INTEGER (2^53 - 1).

The models are updated to use 'bigint' type instead of 'number' for
these fields.

In outgoing requests, bigint values are replaced by strings in the
JSON.stringify() replacer. The strings are then replaced by unquoted
numbers in the JSON request.

In incoming JSON responses, long numbers are replaced by strings prior
to parsing, and the JSON.parse() reviver will replace those strings by
either bigint or number values, depending on the field. For bigint
fields, small numbers are replaced by their bigint value.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>