### PR TITLE
jest.config.json: Apply default VS Code formatting

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -8,7 +8,9 @@
     "^.+\\.tsx?$": "ts-jest"
   },
   "testEnvironment": "jsdom",
-  "testPathIgnorePatterns": ["/lib/"],
+  "testPathIgnorePatterns": [
+    "/lib/"
+  ],
   "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   "moduleFileExtensions": [
     "ts",


### PR DESCRIPTION
This change is the result of using the Format command(s) in VS Code.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>