### PR TITLE
Expanding unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # LC_COLLATE=C sort
 /*.log
 /.DS_Store
+/coverage/
 /lib/
 /node_modules/

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ To keep tests running do:
 ```shell
 yarn test --verbose --watch
 ```
+
+### Test coverage
+
+The following command prints a coverage report to the terminal. As of now it covers all typescript files of the project, including those that are not supposed to have tests.
+
+```shell
+yarn test --coverage --collectCoverageFrom='src/**/*.ts'
+```

--- a/src/models/query/query-helper.test.ts
+++ b/src/models/query/query-helper.test.ts
@@ -6,11 +6,53 @@ describe('Query helper tests', () => {
     const content = {
       first: 1
     };
-    const result = {
-      parameters: content
-    };
+    const query = new Query(content);
     const test = QueryHelper.query(content);
 
-    expect(test).toEqual(result);
+    expect(test).toEqual(query);
+  });
+
+  it('Should build a simple time query', () => {
+    const array = [1, 2, 3];
+    const query = new Query({ [QueryHelper.REQUESTED_TIMES_KEY]: array });
+    const test = QueryHelper.timeQuery(array);
+
+    expect(test).toEqual(query);
+  });
+
+  it('Should build a simple time query with selected items', () => {
+    const times = [1, 2, 3];
+    const items = [4, 5, 6];
+    const query = new Query({
+      [QueryHelper.REQUESTED_TIMES_KEY]: times,
+      [QueryHelper.REQUESTED_ITEMS_KEY]: items
+    });
+    const test = QueryHelper.selectionTimeQuery(times, items);
+
+    expect(test).toEqual(query);
+  });
+
+  it('Should build a simple table query', () => {
+    const columnIds = [1, 2, 3];
+    const index = 2;
+    const count = 1;
+    const query = new Query({
+      [QueryHelper.REQUESTED_TABLE_INDEX_KEY]: index,
+      [QueryHelper.REQUESTED_TABLE_COUNT_KEY]: count,
+      [QueryHelper.REQUESTED_TABLE_COLUMN_IDS_KEY]: columnIds
+    });
+    const test = QueryHelper.tableQuery(columnIds, index, count);
+
+    expect(test).toEqual(query);
+  });
+
+  it('Should split the range into equal parts', () => {
+    const start = 10;
+    const end = 20;
+    const parts = 3;
+    const array = [10, 15, 20];
+    const test = QueryHelper.splitRangeIntoEqualParts(start, end, parts);
+
+    expect(test).toEqual(array);
   });
 });

--- a/src/protocol/__mocks__/rest-client.ts
+++ b/src/protocol/__mocks__/rest-client.ts
@@ -24,6 +24,14 @@ const output: OutputDescriptor = {
 };
 
 export class RestClient {
+  /**
+   * Perform request
+   * Mocks the request call without calling the real backend.
+   * @param verb RestAPI verb
+   * @param url URL to query
+   * @param body Query object as defined by the Query interface
+   * @return A TspClientResponse object
+   */
   private static async performRequest<T>(verb: string, url: string, body?: any): Promise<TspClientResponse<T>> {
     return new Promise((resolve, reject) => {
       let client: TspClientResponse<T> = new TspClientResponse(response.text, response.status, response.statusText);
@@ -62,6 +70,13 @@ export class RestClient {
     });
   }
 
+  /**
+   * Perform GET
+   * T is the expected type of the json object returned by this request
+   * @param url URL to query without query parameters
+   * @param parameters Query parameters. Mapped keys and values are used to build the final URL
+   * @return A TspClientResponse object
+   */
   public static async get<T>(url: string, parameters?: Map<string, string>): Promise<TspClientResponse<T>> {
     let getUrl = url;
     if (parameters) {
@@ -71,14 +86,35 @@ export class RestClient {
     return this.performRequest<T>('get', getUrl);
   }
 
+  /**
+   * Perform POST
+   * T is the expected type of the json object returned by this request
+   * @param url URL to query
+   * @param body Query object as defined by the Query interface
+   * @return A TspClientResponse object
+   */
   public static async post<T>(url: string, body?: any): Promise<TspClientResponse<T>> {
     return this.performRequest<T>('post', url, body);
   }
 
+  /**
+   * Perform PUT
+   * T is the expected type of the json object returned by this request
+   * @param url URL to query
+   * @param body Query object as defined by the Query interface
+   * @return A TspClientResponse object
+   */
   public static async put<T>(url: string, body?: any): Promise<TspClientResponse<T>> {
     return this.performRequest<T>('put', url, body);
   }
 
+  /**
+   * Perform DELETE
+   * T is the expected type of the json object returned by this request
+   * @param url URL to query without query parameters
+   * @param parameters Query parameters. Mapped keys and values are use to build the final URL
+   * @return A TspClientResponse object
+   */
   public static async delete<T>(url: string, parameters?: Map<string, string>): Promise<TspClientResponse<T>> {
     let deleteUrl = url;
     if (parameters) {
@@ -88,6 +124,11 @@ export class RestClient {
     return this.performRequest<T>('delete', deleteUrl);
   }
 
+  /**
+   * Encode URL parameters
+   * @param parameters Query parameters. Mapped keys and values are used to build the final URL
+   * @return Encoded string
+   */
   private static encodeURLParameters(parameters: Map<string, string>): string {
     if (parameters.size) {
       const urlParameters: string = '?';
@@ -100,6 +141,11 @@ export class RestClient {
     return '';
   }
 
+  /**
+    * Extract parameters
+    * @param url URL string
+    * @return String containing the parameters extracted from the url
+    */
   public static extractParameters(url: string): string {
     const topic = url.includes('traces') ? 'traces' : 'experiments';
     const ar = url.split(topic + '/');

--- a/src/protocol/__mocks__/rest-client.ts
+++ b/src/protocol/__mocks__/rest-client.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { TspClientResponse } from '../tsp-client-response';
+import { OutputDescriptor } from '../../models/output-descriptor';
 
 const response = {
   text: 'Test',
@@ -7,17 +8,53 @@ const response = {
   statusText: 'Success'
 };
 
+const output: OutputDescriptor = {
+  id: 'One',
+  name: 'Test',
+  description: 'Test description',
+  type: 'Test type',
+  queryParameters: new Map([
+    ['key1', 'value1'],
+    ['key2', 'value2']
+  ]),
+  start: 1,
+  end: 10,
+  final: false,
+  compatibleProviders: ['One', 'Two']
+};
+
 export class RestClient {
   private static async performRequest<T>(verb: string, url: string, body?: any): Promise<TspClientResponse<T>> {
     return new Promise((resolve, reject) => {
       let client: TspClientResponse<T> = new TspClientResponse(response.text, response.status, response.statusText);
 
-      if (url.includes('traces')) {
-        let ar = url.split('traces/');
-        let i = url.indexOf('traces');
-        let params = url.slice(i + 7);
+      if (verb === 'get') {
+        // In case a GET request contains parameters in the URL, extract them
+        let params = this.extractParameters(url);
+        if (params.length > 0) {
+          if (params.includes('output')) {
+            params = params.slice(0, params.indexOf('/'));
+            let ar = [output];
+            ar[0].id = params;
+            client = new TspClientResponse(JSON.stringify(ar), response.status, response.statusText);
+          } else {
+            client = new TspClientResponse(params, response.status, response.statusText);
+          }
+        }
+      } else if (verb === 'post') {
+        // Check if POST request contains parameters in body
+        if (typeof body === 'object' && body.parameters !== null) {
+          const result = body.parameters.test;
+          client = new TspClientResponse(result, response.status, response.statusText);
+        } else {
+          reject();
+        }
+      } else if (verb === 'delete' || verb === 'put') {
+        const params = this.extractParameters(url);
         if (params.length > 0) {
           client = new TspClientResponse(params, response.status, response.statusText);
+        } else {
+          reject();
         }
       }
 
@@ -25,12 +62,6 @@ export class RestClient {
     });
   }
 
-  /**
-   * Perform GET
-   * T is the expected type of the json object returned by this request
-   * @param url URL to query without query parameters
-   * @param parameters Query parameters. Map keys and values are used to build the final URL
-   */
   public static async get<T>(url: string, parameters?: Map<string, string>): Promise<TspClientResponse<T>> {
     let getUrl = url;
     if (parameters) {
@@ -38,6 +69,23 @@ export class RestClient {
       getUrl = getUrl.concat(urlParameters);
     }
     return this.performRequest<T>('get', getUrl);
+  }
+
+  public static async post<T>(url: string, body?: any): Promise<TspClientResponse<T>> {
+    return this.performRequest<T>('post', url, body);
+  }
+
+  public static async put<T>(url: string, body?: any): Promise<TspClientResponse<T>> {
+    return this.performRequest<T>('put', url, body);
+  }
+
+  public static async delete<T>(url: string, parameters?: Map<string, string>): Promise<TspClientResponse<T>> {
+    let deleteUrl = url;
+    if (parameters) {
+      const urlParameters = this.encodeURLParameters(parameters);
+      deleteUrl = deleteUrl.concat(urlParameters);
+    }
+    return this.performRequest<T>('delete', deleteUrl);
   }
 
   private static encodeURLParameters(parameters: Map<string, string>): string {
@@ -50,5 +98,11 @@ export class RestClient {
       return urlParameters.concat(parametersArray.join('&'));
     }
     return '';
+  }
+
+  public static extractParameters(url: string): string {
+    const topic = url.includes('traces') ? 'traces' : 'experiments';
+    const ar = url.split(topic + '/');
+    return url.slice(url.indexOf(topic) + topic.length + 1);
   }
 }

--- a/src/protocol/rest-client.ts
+++ b/src/protocol/rest-client.ts
@@ -15,7 +15,8 @@ export class RestClient {
                 'Content-Type': 'application/json'
             },
             method: verb,
-            body: jsonBody});
+            body: jsonBody
+        });
         const text = await response.text();
         return new TspClientResponse(text, response.status, response.statusText);
     }
@@ -24,7 +25,7 @@ export class RestClient {
      * Perform GET
      * T is the expected type of the json object returned by this request
      * @param url URL to query without query parameters
-     * @param parameters Query parameters. Map keys and values are used to build the final URL
+     * @param parameters Query parameters. Mapped keys and values are used to build the final URL
      */
     public static async get<T>(url: string, parameters?: Map<string, string>): Promise<TspClientResponse<T>> {
         let getUrl = url;
@@ -59,7 +60,7 @@ export class RestClient {
      * Perform DELETE
      * T is the expected type of the json object returned by this request
      * @param url URL to query without query parameters
-     * @param parameters Query parameters. Map keys and values are used to build the final URL
+     * @param parameters Query parameters. Mapped keys and values are used to build the final URL
      */
     public static async delete<T>(url: string, parameters?: Map<string, string>): Promise<TspClientResponse<T>> {
         let deleteUrl = url;

--- a/src/protocol/tsp-client.test.ts
+++ b/src/protocol/tsp-client.test.ts
@@ -1,6 +1,8 @@
 import { TspClient } from './tsp-client';
 import { TspClientResponse } from './tsp-client-response';
 import { Trace } from '../models/trace';
+import { Query } from '../models/query/query';
+import { OutputDescriptor } from '../models/output-descriptor';
 
 jest.mock('./rest-client');
 
@@ -8,26 +10,96 @@ const client = new TspClient('http://localhost');
 
 describe('Tsp client tests', () => {
   it('Should fetch traces', async () => {
+    const input = new TspClientResponse('Test', 200, 'Success');
     const response = await client.fetchTraces();
-    const check = {
-      text: 'Test',
-      statusCode: 200,
-      statusMessage: 'Success'
-    };
 
-    expect(response).toEqual(check);
+    expect(response).toEqual(input);
   });
 
   it('Should fetch a specific trace', async () => {
     const traceUUID = '123';
+    const input = new TspClientResponse(traceUUID, 200, 'Success');
     const response = await client.fetchTrace(traceUUID);
-    const check = {
-      text: traceUUID,
-      statusCode: 200,
-      statusMessage: 'Success',
-      responseModel: +traceUUID
-    };
 
-    expect(response).toEqual(check);
+    expect(response).toEqual(input);
+  });
+
+  it('Should open a trace in the server', async () => {
+    const check = '123';
+    const query = new Query({ test: check });
+    const input = new TspClientResponse(check, 200, 'Success');
+    const response = await client.openTrace(query);
+
+    expect(response).toEqual(input);
+  });
+
+  it('Should delete a trace', async () => {
+    const traceUUID = '123';
+    const input = new TspClientResponse(traceUUID, 200, 'Success');
+    const response = await client.deleteTrace(traceUUID);
+
+    expect(response).toEqual(input);
+  });
+
+  it('Should fetch experiments', async () => {
+    const input = new TspClientResponse('Test', 200, 'Success');
+    const response = await client.fetchExperiments();
+
+    expect(response).toEqual(input);
+  });
+
+  it('Should fetch an experiment', async () => {
+    const expUUID = '123';
+    const input = new TspClientResponse(expUUID, 200, 'Success');
+    const response = await client.fetchExperiment(expUUID);
+
+    expect(response).toEqual(input);
+  });
+
+  it('Should create an experiment on the server', async () => {
+    const query = new Query({ test: 'Test' });
+    const input = new TspClientResponse('Test', 200, 'Success');
+    const response = await client.createExperiment(query);
+
+    expect(response).toEqual(input);
+  });
+
+  it('Should update an experiment', async () => {
+    const expUUID = '123';
+    const query = new Query({ test: expUUID });
+    const input = new TspClientResponse(expUUID, 200, 'Success');
+    const response = await client.updateExperiment(expUUID, query);
+
+    expect(response).toEqual(input);
+  });
+
+  it('Should delete an experiment', async () => {
+    const expUUID = '123';
+    const input = new TspClientResponse(expUUID, 200, 'Success');
+    const response = await client.deleteExperiment(expUUID);
+
+    expect(response).toEqual(input);
+  });
+
+  it('Should list all the outputs associated to this experiment', async () => {
+    const expUUID = '123';
+    const output: OutputDescriptor = {
+      id: expUUID,
+      name: 'Test',
+      description: 'Test description',
+      type: 'Test type',
+      queryParameters: new Map([
+        ['key1', 'value1'],
+        ['key2', 'value2']
+      ]),
+      start: 1,
+      end: 10,
+      final: false,
+      compatibleProviders: ['One', 'Two']
+    };
+    const input = new TspClientResponse(JSON.stringify([output]), 200, 'Success');
+    const response = await client.experimentOutputs(expUUID);
+
+    expect(response).toEqual(input);
   });
 });


### PR DESCRIPTION
Add more tests to `tps-client.test.ts`.

This commit increases test coverage in these specific ways:

- query-helper.ts:	  from 23% to 75%;
- tsp-client.ts:	  from 8% to 35%;
- tsp-client-response.ts: maintains 56%.

Total coverage:		  from 29% to 55%.

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca>