### PR TITLE
Avoid duplicates in requestedTimes array

### DIFF
--- a/tsp-typescript-client/src/models/query/query-helper.test.ts
+++ b/tsp-typescript-client/src/models/query/query-helper.test.ts
@@ -55,4 +55,14 @@ describe('Query helper tests', () => {
 
     expect(test).toEqual(array);
   });
+
+  it('Should split the range into equal parts without duplicates', () => {
+    const start = BigInt('1234567890123456781');
+    const end = BigInt('1234567890123456785');
+    const parts = 20;
+    const array = [BigInt('1234567890123456781'), BigInt('1234567890123456782'), BigInt('1234567890123456783'), BigInt('1234567890123456784'), BigInt('1234567890123456785')];
+    const test = QueryHelper.splitRangeIntoEqualParts(start, end, parts);
+
+    expect(test).toEqual(array);
+  });
 });

--- a/tsp-typescript-client/src/models/query/query-helper.ts
+++ b/tsp-typescript-client/src/models/query/query-helper.ts
@@ -104,9 +104,9 @@ export class QueryHelper {
             end = start;
             start = tmp;
         }
-        
+        nb = Math.min(nb, Number(end - start + BigInt(1)));
         const result: bigint[] = new Array(nb);
-        const stepSize: number = Number(end - start) / (nb - 1);
+        const stepSize: number = Math.max(1, Number(end - start) / (nb - 1));
         for (let i = 0; i < nb; i++) {
             result[i] = start + BigInt(Math.floor(i * stepSize));
         }


### PR DESCRIPTION
When the requested number of samples is larger than the requested time
range, a smaller array is returned that has every time in the range from
start to end, without duplicates.

Change-Id: Ibfb109ee1df9d9aea0c1eec2e53d38904998e821
Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>