### PR TITLE
depend on json-bigint from the right package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "typescript": "latest"
   },
   "dependencies": {
-    "@types/json-bigint": "^1.0.1",
-    "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
     "node-fetch": "^2.5.0"
   },
   "workspaces": [

--- a/tslint.json
+++ b/tslint.json
@@ -30,6 +30,7 @@
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-var-keyword": true,
+    "no-implicit-dependencies": true,
     "one-line": [
       true,
       "check-open-brace",

--- a/tsp-typescript-client/package.json
+++ b/tsp-typescript-client/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",
+    "@types/json-bigint": "^1.0.1",
     "@types/node": "^11.13.8",
     "@types/node-fetch": "^2.3.3",
     "jest": "^27.1.0",
@@ -21,6 +22,7 @@
     "typescript": "latest"
   },
   "dependencies": {
+    "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
     "node-fetch": "^2.5.0",
     "rimraf": "latest"
   },


### PR DESCRIPTION
What happend is that the PR that introduced the dependency was done
before a refactoring that moved the `tsp-typescript-client` package in a
different folder. But the change to the root `package.json` dependencies
didn't cause a merge conflict, so it stayed this way even though it
meant that the `tsp-typescript-client` would be published without the
new dependency.

Move the dependency from the root of the monorepo to the
`tsp-typescript-client` package.

Signed-off-by: Paul Marechal <paul.marechal@ericsson.com>