### PR TITLE
Fix markdownlint in ./tsp-typescript-client README

### DIFF
--- a/tsp-typescript-client/README.md
+++ b/tsp-typescript-client/README.md
@@ -1,4 +1,4 @@
-## Description
+# Description
 
 A client-side implementation, in typescript, of the Trace Server Protocol (TSP).
 
@@ -6,4 +6,3 @@ A client-side implementation, in typescript, of the Trace Server Protocol (TSP).
 
 - [Trace Server Protocol (TSP)](https://github.com/theia-ide/theia-trace-extension): Protocol specification.
 - [Theia Trace Extension](https://github.com/theia-ide/theia-trace-extension): An reference application that uses the tsp-typescript-client to communicate to a trace-server back-end.
-


### PR DESCRIPTION
Fix the few left-over markdownlint rules [1,2] in VS Code for this file.

[1] https://github.com/DavidAnson/markdownlint/blob/v0.25.1/doc/Rules.md#md012
[2] https://github.com/DavidAnson/markdownlint/blob/v0.25.1/doc/Rules.md#md041

Signed-off-by: Marco Miller <marco.miller@ericsson.com>