### PR TITLE
Catch errors in RestClient

### DIFF
--- a/tsp-typescript-client/src/protocol/test-utils.ts
+++ b/tsp-typescript-client/src/protocol/test-utils.ts
@@ -1,4 +1,5 @@
 import fs = require('fs');
+import { Headers } from 'node-fetch';
 import path = require('path');
 import type { HttpResponse } from './rest-client';
 
@@ -35,6 +36,7 @@ export class FixtureSet {
             status,
             statusText,
             text: await this.readFixture(fixtureName),
+            headers: new Headers({ 'Content-Type': 'application/json' })
         };
     }
 


### PR DESCRIPTION
Catch errors thrown from the HTTP request and return a 503 response.

Catch errors thrown from JSON parser and normalizer and return a
response without model.

Change-Id: I75d6a8019254b6db1c07a91e67a6e8eb438ba57d
Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>